### PR TITLE
(change) add nvidia driver daemonset warning to preemptible GPU doc

### DIFF
--- a/content/en/docs/pipelines/preemptible.md
+++ b/content/en/docs/pipelines/preemptible.md
@@ -106,6 +106,12 @@ Apply the nodepool patch file above by running:
 kubectl --context=${MGMTCTXT} --namespace=${KF_PROJECT} apply -f <path-to-nodepool-file>/preemptible-nodepool.yaml
 ```
 
+Apply the most recent NVIDIA driver daemonset from the GCP container-engine-accelerators repository if your GPU nodepool nvidia-plugin-* pods don't run:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+````
+
 #### For Kubeflow Pipelines standalone only
 
 Alternatively, if you are on Kubeflow Pipelines standalone, or AI Platform Pipelines, you can run this command to create node pool:


### PR DESCRIPTION
Hello 👋 The nvidia-gpu-plugin-* pods do not operate when the preemptible guest accelerator (GPU) ContainerNodePool is created for the GCP GKE kubeflow cluster. The GPU nodepool is attached without any issues after installing the original GCP container-engine-accelerator driver and restarting the pods. This MR updates the documentation to add a line for the installation of the driver's cluster.