### PR TITLE
doc: add anthos API for management cluster setup

### DIFF
--- a/content/en/docs/deploy/project-setup.md
+++ b/content/en/docs/deploy/project-setup.md
@@ -42,7 +42,8 @@ Follow these steps to set up your Google Cloud project:
       krmapihosting.googleapis.com \
       servicecontrol.googleapis.com \
       endpoints.googleapis.com \
-      cloudbuild.googleapis.com
+      cloudbuild.googleapis.com \
+      anthos.googleapis.com
     ```
   Alternatively, you can these APIs can be enabled via Google Cloud Console:
 
@@ -59,6 +60,7 @@ Follow these steps to set up your Google Cloud project:
     * [Config Controller (KRM API Hosting API)](https://console.cloud.google.com/apis/library/krmapihosting.googleapis.com)
     * [Service Control API](https://console.cloud.google.com/apis/library/servicecontrol.googleapis.com)
     * [Google Cloud Endpoints](https://console.cloud.google.com/apis/library/endpoints.googleapis.com)
+    * [Anthos](https://console.cloud.google.com/apis/library/anthos.googleapis.com)
 
 * If you are using the
   [Google Cloud Free Program](https://cloud.google.com/free/docs/gcp-free-tier) or the


### PR DESCRIPTION
if the anthos API not enabled in the GCP project, the `make create-cluster` command for creating management cluster will have error 
```
gcloud anthos config controller create kf-management --location=us-east1
ERROR: (gcloud.anthos.config.controller.create) PERMISSION_DENIED: please enable  anthos.googleapis.com.
```